### PR TITLE
Update rating UI, fix manual session linking, and separate legacy bot posts

### DIFF
--- a/lib/reforger-github-sync.ts
+++ b/lib/reforger-github-sync.ts
@@ -5,8 +5,10 @@ import { ObjectId } from "mongodb";
 import { makeSafeName } from "./missionsHelpers";
 import fs from "fs";
 import { logReforgerAction, LOG_ACTION } from "./logging";
+import dns from "dns";
 
-
+// Fix for Node 17+ resolving IPv6 first and throwing ENOTFOUND on environments without IPv6 routing
+dns.setDefaultResultOrder("ipv4first");
 
 const GITHUB_API_BASE = "https://api.github.com/repos/Global-Conflicts-ArmA/gc-reforger-missions";
 const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/Global-Conflicts-ArmA/gc-reforger-missions/master";

--- a/pages/api/reforger-missions/[uniqueName]/history/index.ts
+++ b/pages/api/reforger-missions/[uniqueName]/history/index.ts
@@ -4,7 +4,7 @@ import MyMongo from "../../../../../lib/mongodb";
 import { CREDENTIAL } from "../../../../../middleware/check_auth_perms";
 import { ObjectId } from "bson";
 import axios from "axios";
-import { postNewMissionHistory, callBotEditMessage } from "../../../../../lib/discordPoster";
+import { callBotEditMessage } from "../../../../../lib/discordPoster";
 import { hasCredsAny } from "../../../../../lib/credsChecker";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../../auth/[...nextauth]";
@@ -198,30 +198,7 @@ apiRoute.post(async (req: NextApiRequest, res: NextApiResponse) => {
         }
     }
 
-    if (process.env.NODE_ENV !== 'development') {
-        try {
-            const botResponse = await axios.get(
-                `${process.env.BOT_URL ?? "http://globalconflicts.net:3001"}/users/${mission.authorID}`,
-                { timeout: 5000 }
-            );
 
-            postNewMissionHistory({
-                leaders: history.leaders,
-                isNew: true,
-                name: mission.name,
-                uniqueName: uniqueName as string,
-                author: botResponse.data.nickname ?? botResponse.data.displayName,
-                authorId: botResponse.data.userId,
-                displayAvatarURL: botResponse.data.displayAvatarURL,
-                outcome: history.outcome,
-                gmNote: history.gmNote,
-                aarReplayLink: history.aarReplayLink,
-                discordThreadId: history.discordThreadId,
-            });
-        } catch (error) {
-            console.error("Error posting history to Discord:", error);
-        }
-    }
 
     // ── Update Discord live-session message if the client provided explicit IDs ──
     // discordMessageId/threadId come from the session selector in the UI.
@@ -333,30 +310,7 @@ apiRoute.put(async (req: NextApiRequest, res: NextApiResponse) => {
 		}
 	);
 
-    if (process.env.NODE_ENV !== 'development') {
-        try {
-            const botResponse = await axios.get(
-                `${process.env.BOT_URL ?? "http://globalconflicts.net:3001"}/users/${mission.authorID}`,
-                { timeout: 5000 }
-            );
 
-            postNewMissionHistory({
-                leaders: history.leaders,
-                isNew: false,
-                name: mission.name,
-                uniqueName: uniqueName as string,
-                author: botResponse.data.nickname ?? botResponse.data.displayName,
-                authorId: botResponse.data.userId,
-                displayAvatarURL: botResponse.data.displayAvatarURL,
-                outcome: history.outcome,
-                gmNote: history.gmNote,
-                aarReplayLink: history.aarReplayLink,
-                discordThreadId: history.discordThreadId,
-            });
-        } catch (error) {
-            console.error("Error posting history update to Discord:", error);
-        }
-    }
 
     // ── Update Discord live-session message if the client provided explicit IDs ──
     if (history.discordMessageId && history.discordThreadId) {

--- a/pages/api/server-sessions/[id].ts
+++ b/pages/api/server-sessions/[id].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import nextConnect from "next-connect";
-import { ObjectId } from "mongodb";
+import { ObjectId } from "bson";
 import MyMongo from "../../../lib/mongodb";
 import { CREDENTIAL } from "../../../middleware/check_auth_perms";
 import { getServerSession } from "next-auth/next";
@@ -23,8 +23,15 @@ apiRoute.get(async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     const { id } = req.query;
+    let objectId: ObjectId;
+    try {
+        objectId = new ObjectId(id as string);
+    } catch (err) {
+        return res.status(400).json({ error: "Invalid session ID format" });
+    }
+
     const db = (await MyMongo).db("prod");
-    const doc = await db.collection("server_sessions").findOne({ _id: new ObjectId(id as string) });
+    const doc = await db.collection("server_sessions").findOne({ _id: objectId });
 
     if (!doc) return res.status(404).json({ error: "Session not found" });
 
@@ -40,6 +47,13 @@ apiRoute.patch(async (req: NextApiRequest, res: NextApiResponse) => {
     const { id } = req.query;
     const { missionUniqueName } = req.body;
 
+    let objectId: ObjectId;
+    try {
+        objectId = new ObjectId(id as string);
+    } catch (err) {
+        return res.status(400).json({ error: "Invalid session ID format" });
+    }
+
     const db = (await MyMongo).db("prod");
 
     let update: any;
@@ -51,7 +65,7 @@ apiRoute.patch(async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     await db.collection("server_sessions").updateOne(
-        { _id: new ObjectId(id as string) },
+        { _id: objectId },
         update
     );
 
@@ -65,8 +79,16 @@ apiRoute.delete(async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     const { id } = req.query;
+    
+    let objectId: ObjectId;
+    try {
+        objectId = new ObjectId(id as string);
+    } catch (err) {
+        return res.status(400).json({ error: "Invalid session ID format" });
+    }
+
     const db = (await MyMongo).db("prod");
-    await db.collection("server_sessions").deleteOne({ _id: new ObjectId(id as string) });
+    await db.collection("server_sessions").deleteOne({ _id: objectId });
 
     res.status(200).json({ ok: true });
 });

--- a/pages/missions/[uniqueName]/index.tsx
+++ b/pages/missions/[uniqueName]/index.tsx
@@ -763,7 +763,7 @@ export default function MissionDetails({
 
 
 							style={{ paddingTop: 1, paddingBottom: 5 }}
-							className="text-2xl">{selectedRating?.emoji} </span> <span className="flex-1 p-2 text-sm">{selectedRating?.name ?? "Rate this mission"} </span>
+							className="text-2xl">{selectedRating?.emoji} </span> <span className="flex-1 p-2 text-sm">{selectedRating?.name ?? "Rate this specific session"} </span>
 						<ChevronDoubleDownIcon spacing={0} height={15} className={` transition-all mr-2 duration-150 ${open ? 'rotate-180' : 'rotate-0'}`} /></Listbox.Button>
 					<Transition
 						show={open}
@@ -841,9 +841,9 @@ export default function MissionDetails({
 
 
 	const possibleRatings = [
-		{ value: "positive", emoji: "👍", name: 'The mission is well made and interesting' },
-		{ value: "neutral", emoji: "🆗", name: 'It\'s alright ' },
-		{ value: "negative", emoji: "👎", name: 'The mission has concept issues' }
+		{ value: "positive", emoji: "👍", name: 'Good - I liked this mission.' },
+		{ value: "neutral", emoji: "🆗", name: 'Okay - This mission was fine.' },
+		{ value: "negative", emoji: "👎", name: 'Bad - I did not like this mission.' }
 	]
 
 	const [selectedRating, setSelectedRating] = useState<any>(


### PR DESCRIPTION
### Description
This PR contains several fixes and improvements for the Arma Reforger mission rating and session tracking systems. It is
designed to be deployed alongside the corresponding `discord-bot` PR.

### Changes Made
- **Separated Legacy Discord Posts:** Removed the `postNewMissionHistory` call from the Reforger history API routes.
Reforger missions will now exclusively use the live-session bot system, while the legacy "New mission history recorded"
message will correctly only trigger for Arma 3 missions.
- **Updated Rating Terminology:** Changed the rating dropdown options to use extremely simple, universally understood
language to better accommodate our international community.
- *Prompt:* "Rate this specific session"
- *Options:* "Good - I liked this mission", "Okay - This mission was fine", "Bad - I did not like this mission".
- **Fixed Manual Session Linking:** Fixed a bug where manually linking a mission to a session on the `/server-sessions`
page would crash and return a "Failed to save" toast error. Corrected the `ObjectId` import (using `bson` instead of
`mongodb`) and wrapped the ID parsing in a `try/catch` block.

### Related PRs
- Requires `discord-bot` PR: https://github.com/Global-Conflicts-ArmA/discord-bot/pull/30